### PR TITLE
Distances and angles between atoms can be edited manually or by slider

### DIFF
--- a/Atomic.xcodeproj/project.pbxproj
+++ b/Atomic.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		C01D7FCA280C5F86003EBA5D /* LineChartView in Frameworks */ = {isa = PBXBuildFile; productRef = C01D7FC9280C5F86003EBA5D /* LineChartView */; };
 		C01FD3AE278B4E2F00E0A5AD /* InstanceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C01FD3AC278B4E2C00E0A5AD /* InstanceManager.swift */; };
 		C0205A6B280C632200BCD688 /* Commands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0205A6A280C632200BCD688 /* Commands.swift */; };
+		C0209CDF280D584A00ED9AEF /* SceneKitExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0209CDE280D584A00ED9AEF /* SceneKitExtensions.swift */; };
+		C0209CE0280D584A00ED9AEF /* SceneKitExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0209CDE280D584A00ED9AEF /* SceneKitExtensions.swift */; };
 		C021717F27E3E269007ACD2F /* ToolBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C021717E27E3E269007ACD2F /* ToolBar.swift */; };
 		C021718027E3E269007ACD2F /* ToolBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C021717E27E3E269007ACD2F /* ToolBar.swift */; };
 		C0265CA52766A30100C5219E /* WelcomeMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0265CA42766A30100C5219E /* WelcomeMessage.swift */; };
@@ -83,6 +85,7 @@
 		C01D7FA5280C4734003EBA5D /* AtomicLineChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicLineChartView.swift; sourceTree = "<group>"; };
 		C01FD3AC278B4E2C00E0A5AD /* InstanceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceManager.swift; sourceTree = "<group>"; };
 		C0205A6A280C632200BCD688 /* Commands.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Commands.swift; sourceTree = "<group>"; };
+		C0209CDE280D584A00ED9AEF /* SceneKitExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneKitExtensions.swift; sourceTree = "<group>"; };
 		C021717E27E3E269007ACD2F /* ToolBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolBar.swift; sourceTree = "<group>"; };
 		C0265CA42766A30100C5219E /* WelcomeMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeMessage.swift; sourceTree = "<group>"; };
 		C041E25D2774B96D005790EE /* Molecule3DView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Molecule3DView.swift; sourceTree = "<group>"; };
@@ -183,6 +186,7 @@
 				F06AA47D26E77F5200387EBA /* Assets.xcassets */,
 				C05F5CA82785A48C00F3B588 /* GeneralExtensions.swift */,
 				C0CE163828006C1200A35AA3 /* UsefulFunctions.swift */,
+				C0209CDE280D584A00ED9AEF /* SceneKitExtensions.swift */,
 				C0BEB2BA276A9E66006F37A5 /* CustomColors.swift */,
 				C09441342761F76F00680075 /* ViewExtensions.swift */,
 				F06AA49726E7801200387EBA /* AtomicMainController.swift */,
@@ -474,6 +478,7 @@
 				C0DCCED5276A3E980085CD1D /* AtomicMainController.swift in Sources */,
 				C0CE163A28006C1200A35AA3 /* UsefulFunctions.swift in Sources */,
 				C041E25F2774B96D005790EE /* Molecule3DView.swift in Sources */,
+				C0209CE0280D584A00ED9AEF /* SceneKitExtensions.swift in Sources */,
 				C0DCCEC6276A3D670085CD1D /* ChartsViews.swift in Sources */,
 				C0205A6B280C632200BCD688 /* Commands.swift in Sources */,
 				C01D7FA7280C4734003EBA5D /* AtomicLineChartView.swift in Sources */,
@@ -514,6 +519,7 @@
 				C041E25E2774B96D005790EE /* Molecule3DView.swift in Sources */,
 				C05F5CA72784720B00F3B588 /* UIToolbars_iPad.swift in Sources */,
 				F06AA49C26E7801200387EBA /* ChartsViews.swift in Sources */,
+				C0209CDF280D584A00ED9AEF /* SceneKitExtensions.swift in Sources */,
 				F006ADC326FBD3B500FD2F33 /* PeriodicTableView.swift in Sources */,
 				C0E1371B277F33D3009ACCB6 /* InputfileView.swift in Sources */,
 				C01D7FA6280C4734003EBA5D /* AtomicLineChartView.swift in Sources */,

--- a/Shared/GeneralExtensions.swift
+++ b/Shared/GeneralExtensions.swift
@@ -16,6 +16,16 @@ extension Double {
     func stringWith(_ decimals: Int) -> String {
         return String(format: "%.\(decimals)f", self)
     }
+    
+    /// Transforms the angle defined by this value from degrees to radians.
+    func toRadians() -> Double {
+        return self * (.pi / 180)
+    }
+    
+    /// Transforms the angle defined by this value from radians to degrees.
+    func toDegrees() -> Double {
+        return self * (180 / .pi)
+    }
 }
 
 extension CGFloat {

--- a/Shared/GeneralExtensions.swift
+++ b/Shared/GeneralExtensions.swift
@@ -45,16 +45,3 @@ extension Float {
         }
     }
 }
-
-extension SCNVector3: Equatable {
-    public static func == (lhs: SCNVector3, rhs: SCNVector3) -> Bool {
-        if lhs.x == rhs.x {
-            if lhs.y == rhs.y {
-                if  lhs.z == rhs.z {
-                    return true
-                }
-            }
-        }
-        return false
-    }
-}

--- a/Shared/Renderer/MoleculeRenderer.swift
+++ b/Shared/Renderer/MoleculeRenderer.swift
@@ -282,6 +282,16 @@ class MoleculeRenderer: ObservableObject {
         case selectAtom
     }
     
+    func editDistanceOrAngle(_ newValue: String) -> Double? {
+        if selectedAtoms.count == 2 {
+            return editDistance(newValue)
+        }
+        if selectedAtoms.count == 3 {
+            return editAngle(newValue)
+        }
+        return nil
+    }
+    
     /// Measures the distance or the angle between two and three selected nodes, respectively and depending on the selected nodes quantity.
     private func measureNodes() {
         if selectedAtoms.count == 2 {
@@ -306,15 +316,15 @@ class MoleculeRenderer: ObservableObject {
     }
     
     /// If the user changes manually measuredDistance, the selected nodes are updated to reflect the change.
-    func editDistance(_ newValue: String) -> Double? {
+    private func editDistance(_ newValue: String) -> Double? {
         if selectedAtoms.isEmpty {return nil}
         let pos1 = selectedAtoms[0].selectedNode.position
         let pos2 = selectedAtoms[1].selectedNode.position
-        let vector = (pos1 - pos2).normalizedVector()
+        let vector = (pos1 - pos2).normalized()
         
         guard let i = Float(newValue) else {return nil}
         
-        if i < 0.01 {return nil}
+        if i < 0.01 {return nil} // Limit of proximity
         
         let j = CGFloat(i)
         
@@ -327,6 +337,19 @@ class MoleculeRenderer: ObservableObject {
         
         return Double(newDistance.norm)
         
+    }
+    
+    private func editAngle(_ newValue: String) -> Double? {
+        let pos1 = selectedAtoms[0].selectedNode.position
+        let pos2 = selectedAtoms[1].selectedNode.position
+        let pos3 = selectedAtoms[2].selectedNode.position
+        
+        let vector1 = (pos1 - pos2).normalized()
+        let vector2 = (pos3 - pos2).normalized()
+        
+        let cross = vector1.crossProduct(vector2)
+        
+        return Double(cross.norm)
     }
     
     //MARK: Scene renderer controller

--- a/Shared/Renderer/MoleculeRenderer.swift
+++ b/Shared/Renderer/MoleculeRenderer.swift
@@ -283,6 +283,13 @@ class MoleculeRenderer: ObservableObject {
     @Published var measuredDistangle: String = ""
     @Published var showDistangle: Bool = false
     
+    var bindingDoubleDistangle: Binding<Double> {
+        Binding {
+            filterStoD(self.measuredDistangle, maxValue: 5, minValue: 0.5)
+        } set: {self.measuredDistangle = String($0); self.editDistanceOrAngle()}
+
+    }
+    
     func editDistanceOrAngle() {
         
         if selectedAtoms.count == 2 {

--- a/Shared/Renderer/MoleculeRenderer.swift
+++ b/Shared/Renderer/MoleculeRenderer.swift
@@ -273,7 +273,7 @@ class MoleculeRenderer: ObservableObject {
     @Published var selectedTool: Tools = .selectAtom
     
     /// Distance of selected nodes
-    @Published var measuredDistance: String? = nil
+    @Published var measuredDistance: Double? = nil
     
     /// Available tools
     enum Tools {
@@ -283,11 +283,11 @@ class MoleculeRenderer: ObservableObject {
     }
     
     /// Measures the distance or the angle between two and three selected nodes, respectively and depending on the selected nodes quantity.
-    func measureNodes() {
+    private func measureNodes() {
         if selectedAtoms.count == 2 {
             let pos1 = selectedAtoms[0].selectedNode.position
             let pos2 = selectedAtoms[1].selectedNode.position
-            measuredDistance = distance(from: pos1, to: pos2).stringWith(3) + " Å"
+            measuredDistance = distance(from: pos1, to: pos2)
             return
             
         }
@@ -297,12 +297,36 @@ class MoleculeRenderer: ObservableObject {
             let pos2 = selectedAtoms[1].selectedNode.position
             let pos3 = selectedAtoms[2].selectedNode.position
             
-            measuredDistance = angle(pos1: pos1, pos2: pos2, pos3: pos3).stringWith(3) + " º"
+            measuredDistance = angle(pos1: pos1, pos2: pos2, pos3: pos3)
             return
         }
         
         // Fallthrough
         measuredDistance = nil
+    }
+    
+    /// If the user changes manually measuredDistance, the selected nodes are updated to reflect the change.
+    func editDistance(_ newValue: String) -> Double? {
+        if selectedAtoms.isEmpty {return nil}
+        let pos1 = selectedAtoms[0].selectedNode.position
+        let pos2 = selectedAtoms[1].selectedNode.position
+        let vector = (pos1 - pos2).normalizedVector()
+        
+        guard let i = Float(newValue) else {return nil}
+        
+        if i < 0.01 {return nil}
+        
+        let j = CGFloat(i)
+        
+        let newPosition = SCNVector3Make(vector.x * j, vector.y * j, vector.z * j)
+        
+        selectedAtoms[1].selectedNode.position = newPosition
+        selectedAtoms[1].selectionOrb.position = newPosition
+        
+        let newDistance = newPosition - pos1
+        
+        return Double(newDistance.norm)
+        
     }
     
     //MARK: Scene renderer controller

--- a/Shared/SceneKitExtensions.swift
+++ b/Shared/SceneKitExtensions.swift
@@ -6,6 +6,14 @@
 //
 
 import SceneKit
+import SwiftUI
+
+///Universal Float (iOS) or CGFloat (macOS) depending on the platform
+#if os(macOS)
+typealias UFloat = CGFloat
+#elseif os(iOS)
+typealias UFloat = Float
+#endif
 
 extension SCNVector3: Equatable {
     public static func == (lhs: SCNVector3, rhs: SCNVector3) -> Bool {
@@ -22,15 +30,6 @@ extension SCNVector3: Equatable {
 
 /// Make SCNVector3s to be added and substracted
 extension SCNVector3: AdditiveArithmetic {
-    
-    /// The norm of the vector
-    var norm: Float {
-        let floatx = Float(x)
-        let floaty = Float(y)
-        let floatz = Float(z)
-        
-        return sqrt(floatx*floatx + floaty*floaty + floatz*floatz)
-    }
     
     public static func - (lhs: SCNVector3, rhs: SCNVector3) -> SCNVector3 {
         SCNVector3Make(lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z)
@@ -52,8 +51,7 @@ extension SCNVector3 {
     
     /// Returns the normalized vector
     func normalized() -> SCNVector3 {
-        let gnorm = CGFloat(norm)
-        return SCNVector3Make(x / gnorm, y / gnorm, z / gnorm)
+        return SCNVector3Make(dx / magnitudeSquared, dy / magnitudeSquared, dz / magnitudeSquared)
     }
     
     /// Returns the dot product between itself and a second vector.
@@ -68,5 +66,37 @@ extension SCNVector3 {
         let nz = x*v2.y - y*v2.x
         return SCNVector3Make(nx, ny, nz)
     }
+    
+    /// Returns the scaled vector without modifying the original vector
+    func scaled(by rhs: Double) -> SCNVector3 {
+        SCNVector3Make(dx*rhs, dy*rhs, dz*rhs)
+    }
+    
+    // Double counterparts of the x,y and z variables
+    var dx: Double { get {Double(x)} set {x = UFloat(newValue)} }
+    var dy: Double { get {Double(y)} set {y = UFloat(newValue)} }
+    var dz: Double { get {Double(z)} set {z = UFloat(newValue)} }
       
+}
+
+extension SCNVector3: VectorArithmetic {
+    
+    /// Scales and modifies the vector
+    public mutating func scale(by rhs: Double) {
+        dx *= rhs
+        dy *= rhs
+        dz *= rhs
+    }
+    /// The magnitude of the vector
+    public var magnitudeSquared: Double {
+        return sqrt(dx*dx + dy*dy + dz*dz)
+    }
+}
+
+extension CGFloat {
+    /// Initializes a CGFloat with a string
+    public init?(_ string: String) {
+        guard let float = Float(string) else {return nil}
+        self = CGFloat(Float(float))
+    }
 }

--- a/Shared/SceneKitExtensions.swift
+++ b/Shared/SceneKitExtensions.swift
@@ -49,13 +49,24 @@ extension SCNVector3: AdditiveArithmetic {
 /// Useful functions for vectors
 
 extension SCNVector3 {
-
-    func dotProduct(_ v2: SCNVector3) -> Float {
-        self.x * v2.x + self.y * v2.y + self.z * v2.z
+    
+    /// Returns the normalized vector
+    func normalized() -> SCNVector3 {
+        let gnorm = CGFloat(norm)
+        return SCNVector3Make(x / gnorm, y / gnorm, z / gnorm)
     }
     
-    func normalized() -> SCNVector3 {
-        SCNVector3Make(self.x / norm, self.y / norm, self.z / norm)
+    /// Returns the dot product between itself and a second vector.
+    func dotProduct(_ v2: SCNVector3) -> Float {
+        Float(x * v2.x + y * v2.y + z * v2.z)
+    }
+    
+    /// Returns the cross product between itself and a second vector.
+    func crossProduct(_ v2: SCNVector3) -> SCNVector3 {
+        let nx = y*v2.z - z*v2.y
+        let ny = z*v2.x - x*v2.z
+        let nz = x*v2.y - y*v2.x
+        return SCNVector3Make(nx, ny, nz)
     }
       
 }

--- a/Shared/SceneKitExtensions.swift
+++ b/Shared/SceneKitExtensions.swift
@@ -49,14 +49,19 @@ extension SCNVector3: AdditiveArithmetic {
 
 extension SCNVector3 {
     
+    // Double counterparts of the x,y and z variables
+    var dx: Double { get {Double(x)} set {x = UFloat(newValue)} }
+    var dy: Double { get {Double(y)} set {y = UFloat(newValue)} }
+    var dz: Double { get {Double(z)} set {z = UFloat(newValue)} }
+    
     /// Returns the normalized vector
     func normalized() -> SCNVector3 {
         return SCNVector3Make(dx / magnitudeSquared, dy / magnitudeSquared, dz / magnitudeSquared)
     }
     
     /// Returns the dot product between itself and a second vector.
-    func dotProduct(_ v2: SCNVector3) -> Float {
-        Float(x * v2.x + y * v2.y + z * v2.z)
+    func dotProduct(_ v2: SCNVector3) -> Double {
+        dx * v2.dx + dy * v2.dy + dz * v2.dz
     }
     
     /// Returns the cross product between itself and a second vector.
@@ -72,10 +77,19 @@ extension SCNVector3 {
         SCNVector3Make(dx*rhs, dy*rhs, dz*rhs)
     }
     
-    // Double counterparts of the x,y and z variables
-    var dx: Double { get {Double(x)} set {x = UFloat(newValue)} }
-    var dy: Double { get {Double(y)} set {y = UFloat(newValue)} }
-    var dz: Double { get {Double(z)} set {z = UFloat(newValue)} }
+    func rotated(by angle: Double, withRespectTo n: SCNVector3) -> SCNVector3 {
+        
+        let firstTerm = self.scaled(by: cos(angle))
+        let secondTerm = (n.crossProduct(self)).scaled(by: sin(angle))
+        let thridTerm = n.scaled(by: (1 - cos(angle))*(n.dotProduct(self)))
+        
+        return firstTerm + secondTerm + thridTerm
+        
+    }
+    
+    func getSimd() -> SIMD3<Double> {
+        return SIMD3(self)
+    }
       
 }
 
@@ -98,5 +112,11 @@ extension CGFloat {
     public init?(_ string: String) {
         guard let float = Float(string) else {return nil}
         self = CGFloat(Float(float))
+    }
+}
+
+extension SCNQuaternion {
+    public init(axis: SCNVector3, angle: Double) {
+        self = SCNQuaternion(axis.x, axis.y, axis.z, angle)
     }
 }

--- a/Shared/SceneKitExtensions.swift
+++ b/Shared/SceneKitExtensions.swift
@@ -1,0 +1,61 @@
+//
+//  SceneKitExtensions.swift
+//  Atomic
+//
+//  Created by Christian Dominguez on 18/4/22.
+//
+
+import SceneKit
+
+extension SCNVector3: Equatable {
+    public static func == (lhs: SCNVector3, rhs: SCNVector3) -> Bool {
+        if lhs.x == rhs.x {
+            if lhs.y == rhs.y {
+                if  lhs.z == rhs.z {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+}
+
+/// Make SCNVector3s to be added and substracted
+extension SCNVector3: AdditiveArithmetic {
+    
+    /// The norm of the vector
+    var norm: Float {
+        let floatx = Float(x)
+        let floaty = Float(y)
+        let floatz = Float(z)
+        
+        return sqrt(floatx*floatx + floaty*floaty + floatz*floatz)
+    }
+    
+    public static func - (lhs: SCNVector3, rhs: SCNVector3) -> SCNVector3 {
+        SCNVector3Make(lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z)
+    }
+    
+    public static func + (lhs: SCNVector3, rhs: SCNVector3) -> SCNVector3 {
+        SCNVector3Make(lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z)
+    }
+    
+    public static var zero: SCNVector3 {
+        return SCNVector3Make(0, 0, 0)
+    }
+}
+
+
+/// Useful functions for vectors
+
+extension SCNVector3 {
+
+    func dotProduct(_ v2: SCNVector3) -> Float {
+        self.x * v2.x + self.y * v2.y + self.z * v2.z
+    }
+    
+    func normalized() -> SCNVector3 {
+        SCNVector3Make(self.x / norm, self.y / norm, self.z / norm)
+    }
+      
+}

--- a/Shared/Tools/ToolBar.swift
+++ b/Shared/Tools/ToolBar.swift
@@ -61,7 +61,7 @@ struct AtomicToolsView: View {
                 HStack {
                     TextField("", text: Binding(get: {
                         guard let distance = controller.measuredDistance else {return ""}
-                        return distance.stringWith(3)
+                        return String(distance)
                     }, set: { newValue in
                         controller.measuredDistance = controller.editDistance(newValue)
                     }))

--- a/Shared/Tools/ToolBar.swift
+++ b/Shared/Tools/ToolBar.swift
@@ -14,6 +14,7 @@ struct AtomicToolsView: View {
     
     var body: some View {
         ZStack {
+            //MARK: Main toolbar
             HStack {
                 HStack {
                     Image(systemName: "atom")
@@ -54,9 +55,17 @@ struct AtomicToolsView: View {
                 }
             }.frame(maxHeight: 50)
                 .animation(.easeIn, value: controller.selectedAtoms.isEmpty)
+            
+            //MARK: Distance/angle
             if controller.measuredDistance != nil {
                 HStack {
-                    Text(controller.measuredDistance!)
+                    TextField("", text: Binding(get: {
+                        guard let distance = controller.measuredDistance else {return ""}
+                        return distance.stringWith(3)
+                    }, set: { newValue in
+                        controller.measuredDistance = controller.editDistance(newValue)
+                    }))
+                        .textFieldStyle(.plain)
                         .atomicNoButton()
                         .padding(.horizontal)
                     Spacer()

--- a/Shared/Tools/ToolBar.swift
+++ b/Shared/Tools/ToolBar.swift
@@ -63,7 +63,7 @@ struct AtomicToolsView: View {
                         guard let distance = controller.measuredDistance else {return ""}
                         return String(distance)
                     }, set: { newValue in
-                        controller.measuredDistance = controller.editDistance(newValue)
+                        controller.measuredDistance = controller.editDistanceOrAngle(newValue)
                     }))
                         .textFieldStyle(.plain)
                         .atomicNoButton()

--- a/Shared/Tools/ToolBar.swift
+++ b/Shared/Tools/ToolBar.swift
@@ -60,7 +60,7 @@ struct AtomicToolsView: View {
             if controller.showDistangle {
                 HStack {
                     ZStack {
-                        Slider(value: controller.bindingDoubleDistangle, in: 0.5...5)
+                        Slider(value: controller.bindingDoubleDistangle, in: controller.maxRange)
                             .offset(x: 0, y: -30)
                         TextField("Value", text: $controller.measuredDistangle, onCommit: {
                             controller.editDistanceOrAngle()

--- a/Shared/Tools/ToolBar.swift
+++ b/Shared/Tools/ToolBar.swift
@@ -59,14 +59,18 @@ struct AtomicToolsView: View {
             //MARK: Distance/angle
             if controller.showDistangle {
                 HStack {
-                    TextField("Value", text: $controller.measuredDistangle, onCommit: {
-                        controller.editDistanceOrAngle()
-                    })
-                        .multilineTextAlignment(.center)
-                        .textFieldStyle(.plain)
-                        .atomicNoButton()
-                        .frame(maxWidth: 80)
-                        .padding(.horizontal)
+                    ZStack {
+                        Slider(value: controller.bindingDoubleDistangle, in: 0.5...5)
+                            .offset(x: 0, y: -30)
+                        TextField("Value", text: $controller.measuredDistangle, onCommit: {
+                            controller.editDistanceOrAngle()
+                        })
+                            .multilineTextAlignment(.center)
+                            .textFieldStyle(.plain)
+                            .atomicNoButton()
+                    }
+                    .frame(maxWidth: 80)
+                    .padding(.horizontal)
                     Spacer()
                 }
             }

--- a/Shared/Tools/ToolBar.swift
+++ b/Shared/Tools/ToolBar.swift
@@ -57,16 +57,15 @@ struct AtomicToolsView: View {
                 .animation(.easeIn, value: controller.selectedAtoms.isEmpty)
             
             //MARK: Distance/angle
-            if controller.measuredDistance != nil {
+            if controller.showDistangle {
                 HStack {
-                    TextField("", text: Binding(get: {
-                        guard let distance = controller.measuredDistance else {return ""}
-                        return String(distance)
-                    }, set: { newValue in
-                        controller.measuredDistance = controller.editDistanceOrAngle(newValue)
-                    }))
+                    TextField("Value", text: $controller.measuredDistangle, onCommit: {
+                        controller.editDistanceOrAngle()
+                    })
+                        .multilineTextAlignment(.center)
                         .textFieldStyle(.plain)
                         .atomicNoButton()
+                        .frame(maxWidth: 80)
                         .padding(.horizontal)
                     Spacer()
                 }

--- a/Shared/UsefulFunctions.swift
+++ b/Shared/UsefulFunctions.swift
@@ -7,43 +7,6 @@
 
 import SceneKit
 
-
-extension SCNVector3: AdditiveArithmetic {
-    
-    /// The norm of the vector
-    var norm: Float {
-        let floatx = Float(x)
-        let floaty = Float(y)
-        let floatz = Float(z)
-        
-        return sqrt(floatx*floatx + floaty*floaty + floatz*floatz)
-    }
-    
-    func normalizedVector() -> SCNVector3 {
-        #if os(macOS)
-        return SCNVector3Make(x/CGFloat(norm), y/CGFloat(norm), z/CGFloat(norm))
-        #elseif os(iOS)
-        return SCNVector3Make(x/norm, y/norm, z/norm)
-        #endif
-    }
-    
-    public static func * (lhs: SCNVector3, rhs: SCNVector3) -> SCNVector3 {
-        SCNVector3Make(lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z)
-    }
-    
-    public static func - (lhs: SCNVector3, rhs: SCNVector3) -> SCNVector3 {
-        SCNVector3Make(lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z)
-    }
-    
-    public static func + (lhs: SCNVector3, rhs: SCNVector3) -> SCNVector3 {
-        SCNVector3Make(lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z)
-    }
-    
-    public static var zero: SCNVector3 {
-        return SCNVector3Make(0, 0, 0)
-    }
-}
-
 /// Returns the distance from two separated positions
 /// - Parameters:
 ///   - pos1: Position of atom 1
@@ -56,16 +19,12 @@ func distance(from pos1: SCNVector3, to pos2: SCNVector3) -> Double {
 
 /// Returns the angle between three vectors in degrees
 func angle(pos1: SCNVector3, pos2: SCNVector3, pos3: SCNVector3) -> Double {
-    let vector1 = (pos1 - pos2).normalizedVector()
-    let vector2 = (pos3 - pos2).normalizedVector()
+    let vector1 = (pos1 - pos2).normalized()
+    let vector2 = (pos3 - pos2).normalized()
     
-    let dotProduct = vector1.x * vector2.x + vector1.y * vector2.y + vector1.z * vector2.z
+    let dotProduct = vector1.dotProduct(vector2)
     
-    let cosAngle = Float(dotProduct) / (vector1.norm*vector2.norm)
-    
-    print(acos(cosAngle)*57.2958)
-    
-    return Double(acos(dotProduct)) * 57.2958 /// Transformation to degrees
+    return Double(acos(dotProduct)) * 57.2958 /// Conversion to degrees
 }
 
 

--- a/Shared/UsefulFunctions.swift
+++ b/Shared/UsefulFunctions.swift
@@ -14,7 +14,7 @@ import SceneKit
 /// - Returns: The square root of the diference of the vectors
 func distance(from pos1: SCNVector3, to pos2: SCNVector3) -> Double {
     let distanceVector = pos1 - pos2
-    return Double(distanceVector.norm)
+    return Double(distanceVector.magnitudeSquared)
 }
 
 /// Returns the angle between three vectors in degrees
@@ -130,12 +130,36 @@ func viewingZPositionFloat(toSee positions: [SCNVector3]) -> Float {
 ///   - newValue: String to filter
 ///   - maxValue: Max value allowed
 ///   - minValue: Min value allowed
-/// - Returns: An integer of the filtered string
+/// - Returns: An integer of the filtered string or the minimum value in case the string is empty
 func filterStoI(_ newValue: String, maxValue: Int, minValue: Int = 1) -> Int {
     
-    if newValue.isEmpty { return 1 }
+    if newValue.isEmpty { return minValue }
     
     let filtered = Int(newValue.filter { "0123456789".contains($0) }) ?? 1
+    
+    if filtered < minValue {
+        return minValue
+    }
+    
+    if filtered > maxValue {
+        return maxValue
+    }
+
+    return filtered // Fallthrough
+}
+
+
+/// Filters a string value to a double value between a max and a min value.
+/// - Parameters:
+///   - newValue: String to filter
+///   - maxValue: Max value allowed
+///   - minValue: Min value allowed
+/// - Returns: The double of the filtered string or the min value if the string cannot be converted
+func filterStoD(_ newValue: String, maxValue: Double, minValue: Double = 0) -> Double {
+    
+    if newValue.isEmpty { return minValue }
+    
+    let filtered = Double(newValue.filter { "0123456789.".contains($0) }) ?? minValue
     
     if filtered < minValue {
         return minValue

--- a/Shared/UsefulFunctions.swift
+++ b/Shared/UsefulFunctions.swift
@@ -24,7 +24,7 @@ func angle(pos1: SCNVector3, pos2: SCNVector3, pos3: SCNVector3) -> Double {
     
     let dotProduct = vector1.dotProduct(vector2)
     
-    return Double(acos(dotProduct)) * 57.2958 /// Conversion to degrees
+    return Double(acos(dotProduct)) * (180/Double.pi)  /// Conversion to degrees
 }
 
 

--- a/Shared/UsefulFunctions.swift
+++ b/Shared/UsefulFunctions.swift
@@ -24,7 +24,7 @@ func angle(pos1: SCNVector3, pos2: SCNVector3, pos3: SCNVector3) -> Double {
     
     let dotProduct = vector1.dotProduct(vector2)
     
-    return Double(acos(dotProduct)) * (180/Double.pi)  /// Conversion to degrees
+    return acos(dotProduct).toDegrees() /// Conversion to degrees
 }
 
 
@@ -35,7 +35,7 @@ func averageDistance(of positions: [SCNVector3]) -> SCNVector3 {
     
     var meanPos = SCNVector3Zero.self
     
-    #warning("TODO: Think of a universal solution for CGFloat/Float duality")
+    #warning("TODO: Think of a universal solution for CGFloat/Float duality") // Its done with UFloat, but changes are still to be applied
     // Why does SceneKit uses Floats or CGFloats depending on the OS. WHY?
     #if os(macOS)
     let npos = CGFloat(positions.count)

--- a/Shared/UsefulFunctions.swift
+++ b/Shared/UsefulFunctions.swift
@@ -35,6 +35,7 @@ func averageDistance(of positions: [SCNVector3]) -> SCNVector3 {
     
     var meanPos = SCNVector3Zero.self
     
+    #warning("TODO: Think of a universal solution for CGFloat/Float duality")
     // Why does SceneKit uses Floats or CGFloats depending on the OS. WHY?
     #if os(macOS)
     let npos = CGFloat(positions.count)


### PR DESCRIPTION
When selecting 2 atoms, a slider above the distance can ve moved to edit the distance between the atoms.

When selecting 3 atoms, the slider edits the angle between them.

Methods added to MoleculeRender:
-editDistance()
-editAngle()
-editDistanceOrAngle()

When the distance/angle textfield is edited, editDistanceOrAngle gets called and modifies the positions of the vectors depending on the amount of selected nodes. 2 for the distance (editDistance()), 3 for the angle (editAngle()).

SCNVector3 has brand new methods:
- Cross product
- Dot product
- Normalized vector
- getSimd method returns the SIMD3 array of the x y and z components of the vector

SCNVector3 has new computed properties:
-dx, dy, dz. Double counterparts of the vector x, y and z variables.

New init to CGFloat to initialize it with a string. To be used when calling UFloat() as a typealias for Float and CGFloat.

General extension to Double to convert between degrees and radians

